### PR TITLE
fix(rsc): resolve inline server action conformance failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Official site: https://vista-js.vercel.app
 
 ## Packages
 
-| Package | Purpose |
-| --- | --- |
+| Package             | Purpose                                                                      |
+| ------------------- | ---------------------------------------------------------------------------- |
 | `@vistagenic/vista` | Framework runtime, CLI, server/client exports, cache APIs, fonts, theme APIs |
-| `create-vista-app` | Scaffolds Vista apps with engine selection and package-manager prompts |
-| `vista-native` | Internal Rust/NAPI bridge used by the repo |
+| `create-vista-app`  | Scaffolds Vista apps with engine selection and package-manager prompts       |
+| `vista-native`      | Internal Rust/NAPI bridge used by the repo                                   |
 
 ## Current Capabilities
 
@@ -21,7 +21,7 @@ Vista currently ships the following core surface:
 
 - App Router-style file conventions under `app/`
 - React Server Components and streaming SSR
-- Server Actions and runtime action manifests
+- Server Actions (both exported modules and inline actions passed across Client Component boundaries) with runtime action manifests
 - Cache APIs: `unstable_cache`, `revalidateTag`, `revalidatePath`, `cacheTag`, `cacheLife`
 - Route groups, parallel routes, interception routes, slot defaults, loading/error/not-found boundaries
 - Segment config support (`dynamic`, `revalidate`, `runtime`, `preferredRegion`, `maxDuration`, `fetchCache`)
@@ -85,6 +85,42 @@ Server helpers from the package:
 import { cookies, headers, draftMode } from 'vista/server';
 ```
 
+## Server Actions
+
+Vista.js supports React 19 Server Actions with full React Server Component conformance. Server Actions can be declared as module exports or defined inline within Server Components and passed across client boundaries:
+
+### Inline Server Actions
+
+Define inline server actions with `'use server'` inside Server Components and pass them as props directly to Client Components:
+
+```tsx
+// app/page.tsx (Server Component)
+import { ActionProbe } from './action-probe';
+
+export default function Page() {
+  async function inlineEcho(value: string) {
+    'use server';
+    return { ok: true, value: `echo-${value}` };
+  }
+
+  return <ActionProbe action={inlineEcho} />;
+}
+```
+
+### Exported Server Actions
+
+Define actions in dedicated files marked with `'use server'` at the top level:
+
+```ts
+// app/actions.ts
+'use server';
+
+export async function updateUser(userId: string, data: FormData) {
+  // Mutation executed securely on the server
+  return { success: true };
+}
+```
+
 ## Monorepo Layout
 
 ```text
@@ -131,18 +167,19 @@ npm --prefix crates/vista-napi run build
 
 ## Common Commands
 
-| Command | Purpose |
-| --- | --- |
-| `pnpm build` | Build the workspace through `flash-run.cjs` |
-| `pnpm dev` | Run workspace dev tasks |
-| `pnpm test` | Full repo test chain |
-| `pnpm test:integrity` | Framework integrity guard |
-| `pnpm test:rsc-conformance` | RSC and route conformance suite |
-| `pnpm test:vista-output` | `.vista` standalone/output verification |
-| `pnpm test:flashpack-dev` | Flashpack dev/restart verification |
-| `pnpm test:flashpack-state` | Flashpack state reuse / cleanup verification |
-| `pnpm bench` | Full benchmark run |
-| `pnpm bench:quick` | Quick benchmark smoke run |
+| Command                     | Purpose                                          |
+| --------------------------- | ------------------------------------------------ |
+| `pnpm build`                | Build the workspace through `flash-run.cjs`      |
+| `pnpm dev`                  | Run workspace dev tasks                          |
+| `pnpm test`                 | Full repo test chain                             |
+| `pnpm test:integrity`       | Framework integrity guard                        |
+| `pnpm test:server-runtime`  | Server runtime & action reference unit tests     |
+| `pnpm test:rsc-conformance` | RSC, server actions, and route conformance suite |
+| `pnpm test:vista-output`    | `.vista` standalone/output verification          |
+| `pnpm test:flashpack-dev`   | Flashpack dev/restart verification               |
+| `pnpm test:flashpack-state` | Flashpack state reuse / cleanup verification     |
+| `pnpm bench`                | Full benchmark run                               |
+| `pnpm bench:quick`          | Quick benchmark smoke run                        |
 
 ## Deployment Notes
 

--- a/packages/vista/dist/build/standalone.js
+++ b/packages/vista/dist/build/standalone.js
@@ -184,18 +184,48 @@ function readRuntimeManifest(projectRoot) {
   }
 }
 
-function installDependencyRoots(projectRoot, manifest) {
-  const candidates = [];
-  let current = projectRoot;
+function findRepoBoundary(startDir) {
+  let current = startDir;
   while (true) {
-    candidates.push(path.join(current, 'node_modules'));
+    if (
+      fs.existsSync(path.join(current, '.git')) ||
+      fs.existsSync(path.join(current, 'pnpm-workspace.yaml'))
+    ) {
+      return current;
+    }
     const parent = path.dirname(current);
     if (parent === current) break;
     current = parent;
   }
+  return null;
+}
+
+function installDependencyRoots(projectRoot, manifest) {
+  const repoBoundary = findRepoBoundary(projectRoot);
+  if (repoBoundary) {
+    const originalNodeModulePaths = Module._nodeModulePaths;
+    Module._nodeModulePaths = function (from) {
+      const paths = originalNodeModulePaths.call(this, from);
+      return paths.filter((p) => p.startsWith(repoBoundary));
+    };
+    if (Array.isArray(module.paths)) {
+      module.paths = Module._nodeModulePaths(projectRoot);
+    }
+  }
+
+  const candidates = [];
 
   for (const relativePath of manifest?.dependencyRootsRelative || []) {
     candidates.push(path.resolve(projectRoot, relativePath));
+  }
+
+  let current = projectRoot;
+  while (true) {
+    candidates.push(path.join(current, 'node_modules'));
+    if (repoBoundary && current === repoBoundary) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
   }
 
   const existing = candidates.filter((entry) => fs.existsSync(entry));
@@ -296,7 +326,9 @@ function generateStandaloneOutput(options) {
         generatedAt: new Date().toISOString(),
         runtimeRootRelative: path_1.default.relative(cwd, runtimeProjectRoot).replace(/\\/g, '/'),
         frameworkRuntimeRelative: path_1.default.relative(cwd, frameworkRuntimeRoot).replace(/\\/g, '/'),
-        standaloneServerRelative: path_1.default.relative(cwd, path_1.default.join(standaloneDir, 'server.js')).replace(/\\/g, '/'),
+        standaloneServerRelative: path_1.default
+            .relative(cwd, path_1.default.join(standaloneDir, 'server.js'))
+            .replace(/\\/g, '/'),
         fileTraceRelative: path_1.default.relative(cwd, fileTracePath).replace(/\\/g, '/'),
         dependencyRootsRelative: [],
     };

--- a/packages/vista/dist/server/rsc-engine.js
+++ b/packages/vista/dist/server/rsc-engine.js
@@ -145,7 +145,9 @@ function parseRevalidationHeader(rawValue) {
     }
     try {
         const parsed = JSON.parse(rawValue);
-        return Array.isArray(parsed) ? parsed.map((entry) => String(entry || '').trim()).filter(Boolean) : [];
+        return Array.isArray(parsed)
+            ? parsed.map((entry) => String(entry || '').trim()).filter(Boolean)
+            : [];
     }
     catch {
         return [];
@@ -343,9 +345,7 @@ function findChunkFiles(cwd, isDev) {
         .filter((name) => name.endsWith('.js') && !name.endsWith('.map') && !name.includes('.hot-update.'));
     // In dev, avoid loading stale production artifacts left from a previous build.
     // Production chunks end with a hash suffix like `main-1a2b3c4d.js`.
-    const normalizedFiles = isDev
-        ? files.filter((name) => !/-[0-9a-f]{8,}\.js$/i.test(name))
-        : files;
+    const normalizedFiles = isDev ? files.filter((name) => !/-[0-9a-f]{8,}\.js$/i.test(name)) : files;
     // Load webpack runtime first, then framework, then the rest alphabetically.
     // This ensures the chunk registry (__webpack_require__) is available before
     // any deferred chunk tries to self-register.
@@ -385,7 +385,10 @@ function normalizeSSRManifest(manifest) {
                 const decoded = decodeURI(key);
                 if (decoded !== key) {
                     aliasEntries.push([decoded, exportsMap]);
-                    aliasEntries.push([decoded.endsWith('#') ? decoded.slice(0, -1) : `${decoded}#`, exportsMap]);
+                    aliasEntries.push([
+                        decoded.endsWith('#') ? decoded.slice(0, -1) : `${decoded}#`,
+                        exportsMap,
+                    ]);
                 }
             }
             catch {
@@ -395,7 +398,10 @@ function normalizeSSRManifest(manifest) {
                 const encoded = encodeURI(key);
                 if (encoded !== key) {
                     aliasEntries.push([encoded, exportsMap]);
-                    aliasEntries.push([encoded.endsWith('#') ? encoded.slice(0, -1) : `${encoded}#`, exportsMap]);
+                    aliasEntries.push([
+                        encoded.endsWith('#') ? encoded.slice(0, -1) : `${encoded}#`,
+                        exportsMap,
+                    ]);
                 }
             }
             catch {
@@ -1318,7 +1324,10 @@ function startRSCServer(options = {}) {
     const proxyRSCRequest = async (req, res) => {
         if (isDev && options.compiler) {
             if (clientCompileState === 'compiling') {
-                res.status(503).type('text/plain').send('[vista] Client bundle is compiling. Retry shortly.');
+                res
+                    .status(503)
+                    .type('text/plain')
+                    .send('[vista] Client bundle is compiling. Retry shortly.');
                 return;
             }
             if (clientCompileState === 'error') {
@@ -1369,10 +1378,8 @@ function startRSCServer(options = {}) {
             res.status(503).type('text/plain').send(getUpstreamUnavailableMessage());
         }
     };
-    app.get('/rsc*', proxyRSCRequest);
-    app.get('/_rsc*', proxyRSCRequest);
-    app.post('/rsc*', proxyRSCRequest);
-    app.post('/_rsc*', proxyRSCRequest);
+    app.get(/^\/(?:_rsc|rsc)(?:\/.*)?$/, proxyRSCRequest);
+    app.post(/^\/(?:_rsc|rsc)(?:\/.*)?$/, proxyRSCRequest);
     // -------------------------------------------------------------------
     // User middleware (middleware.ts at project root)
     // -------------------------------------------------------------------
@@ -1432,9 +1439,7 @@ function startRSCServer(options = {}) {
                     return;
                 }
                 if (clientCompileState === 'error') {
-                    const errorInfos = (clientCompileErrors.length > 0
-                        ? clientCompileErrors
-                        : ['Unknown client build error.']).map((message) => ({ type: 'build', message }));
+                    const errorInfos = (clientCompileErrors.length > 0 ? clientCompileErrors : ['Unknown client build error.']).map((message) => ({ type: 'build', message }));
                     res.status(500).type('text/html').send((0, dev_error_1.renderErrorHTML)(errorInfos));
                     return;
                 }

--- a/packages/vista/dist/server/rsc-upstream.js
+++ b/packages/vista/dist/server/rsc-upstream.js
@@ -41,6 +41,14 @@ function getRouteSuspense() {
     return _RouteSuspense;
 }
 const CjsModule = require('module');
+if (process.env.NODE_PATH) {
+    try {
+        CjsModule._initPaths();
+    }
+    catch (_err) {
+        // ignore
+    }
+}
 // Support CSS imports on server runtime
 require.extensions['.css'] = (m, filename) => {
     if (filename.endsWith('.module.css')) {
@@ -230,6 +238,14 @@ function installSingleReactResolution(cwd) {
             const subPath = request.slice('react-dom/'.length);
             try {
                 return require.resolve(`react-dom/${subPath}`, { paths: [path_1.default.dirname(reactDomPath)] });
+            }
+            catch {
+                // fall through
+            }
+        }
+        if (request === 'react-server-dom-webpack' || request.startsWith('react-server-dom-webpack/')) {
+            try {
+                return resolveFromWorkspace(request, cwd);
             }
             catch {
                 // fall through
@@ -482,6 +498,9 @@ function startUpstream() {
     setupTypeScriptRuntime(runtimeRoot);
     const flightServerPath = resolveFromWorkspace('react-server-dom-webpack/server.node', cwd);
     const flightServer = require(flightServerPath);
+    if (typeof flightServer.registerServerReference === 'function') {
+        (0, runtime_actions_1.setRegisterServerReference)(flightServer.registerServerReference);
+    }
     installClientLoadHook(runtimeRoot, flightServer.createClientModuleProxy);
     (0, fetch_policy_1.installSegmentFetchPolicyShim)();
     const serverManifestPath = path_1.default.join(cwd, constants_1.BUILD_DIR, 'server', 'server-manifest.json');
@@ -779,8 +798,7 @@ function startUpstream() {
             }
         });
     };
-    app.get('/rsc*', handleRSCRequest);
-    app.get('/_rsc*', handleRSCRequest);
+    app.get(/^\/(?:_rsc|rsc)(?:\/.*)?$/, handleRSCRequest);
     // -----------------------------------------------------------------------
     // Server Actions — POST handler
     // -----------------------------------------------------------------------
@@ -870,8 +888,7 @@ function startUpstream() {
             }
         });
     };
-    app.post('/rsc*', handleServerAction);
-    app.post('/_rsc*', handleServerAction);
+    app.post(/^\/(?:_rsc|rsc)(?:\/.*)?$/, handleServerAction);
     const server = app.listen(port, () => {
         console.log(`[vista:rsc:upstream] Listening on http://127.0.0.1:${port}/rsc`);
     });

--- a/packages/vista/dist/server/runtime-actions.d.ts
+++ b/packages/vista/dist/server/runtime-actions.d.ts
@@ -1,5 +1,8 @@
+type RegisterServerReferenceFn = (reference: any, id: string, exportName: string | null) => void;
+export declare function setRegisterServerReference(fn: RegisterServerReferenceFn | null): void;
 export declare function createExportServerReferenceId(filePath: string, exportName?: string): string;
 export declare function createInlineServerActionId(filePath: string, ordinal: number, hint?: string): string;
 export declare function registerInlineServerReference<T extends Function>(reference: T, id: string, exportName?: string): T;
 export declare function registerServerActionModule(moduleExports: unknown, filePath: string): unknown;
 export declare function resolveRegisteredServerReference(id: string): Function | undefined;
+export {};

--- a/packages/vista/dist/server/runtime-actions.js
+++ b/packages/vista/dist/server/runtime-actions.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.setRegisterServerReference = setRegisterServerReference;
 exports.createExportServerReferenceId = createExportServerReferenceId;
 exports.createInlineServerActionId = createInlineServerActionId;
 exports.registerInlineServerReference = registerInlineServerReference;
@@ -12,6 +13,9 @@ const url_1 = require("url");
 const path_1 = __importDefault(require("path"));
 const registeredReferences = new Map();
 let cachedRegisterServerReference;
+function setRegisterServerReference(fn) {
+    cachedRegisterServerReference = fn;
+}
 function getRegisterServerReference() {
     if (cachedRegisterServerReference !== undefined) {
         return cachedRegisterServerReference;
@@ -33,10 +37,10 @@ function normalizeExportName(exportName) {
     return value || 'default';
 }
 function normalizeHint(value) {
-    return String(value || 'action')
+    return (String(value || 'action')
         .trim()
         .replace(/[^a-zA-Z0-9_$]+/g, '_')
-        .replace(/^_+|_+$/g, '') || 'action';
+        .replace(/^_+|_+$/g, '') || 'action');
 }
 function createStableFileUrl(filePath) {
     const href = (0, url_1.pathToFileURL)(path_1.default.resolve(filePath)).href;
@@ -57,7 +61,8 @@ function registerInlineServerReference(reference, id, exportName = 'default') {
     const normalizedExportName = normalizeExportName(exportName);
     const registerServerReference = getRegisterServerReference();
     if (registerServerReference) {
-        registerServerReference(reference, id, normalizedExportName);
+        const effectiveExportName = id.includes('#') ? null : normalizedExportName;
+        registerServerReference(reference, id, effectiveExportName);
     }
     registeredReferences.set(id, reference);
     return reference;

--- a/packages/vista/src/build/standalone.ts
+++ b/packages/vista/src/build/standalone.ts
@@ -1,10 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import {
-  generateRequiredServerFilesManifest,
-  writeArtifactManifest,
-} from './manifest';
+import { generateRequiredServerFilesManifest, writeArtifactManifest } from './manifest';
 import type { ServerManifest } from './rsc/server-manifest';
 
 export interface RuntimeArtifactsManifest {
@@ -261,18 +258,48 @@ function readRuntimeManifest(projectRoot) {
   }
 }
 
-function installDependencyRoots(projectRoot, manifest) {
-  const candidates = [];
-  let current = projectRoot;
+function findRepoBoundary(startDir) {
+  let current = startDir;
   while (true) {
-    candidates.push(path.join(current, 'node_modules'));
+    if (
+      fs.existsSync(path.join(current, '.git')) ||
+      fs.existsSync(path.join(current, 'pnpm-workspace.yaml'))
+    ) {
+      return current;
+    }
     const parent = path.dirname(current);
     if (parent === current) break;
     current = parent;
   }
+  return null;
+}
+
+function installDependencyRoots(projectRoot, manifest) {
+  const repoBoundary = findRepoBoundary(projectRoot);
+  if (repoBoundary) {
+    const originalNodeModulePaths = Module._nodeModulePaths;
+    Module._nodeModulePaths = function (from) {
+      const paths = originalNodeModulePaths.call(this, from);
+      return paths.filter((p) => p.startsWith(repoBoundary));
+    };
+    if (Array.isArray(module.paths)) {
+      module.paths = Module._nodeModulePaths(projectRoot);
+    }
+  }
+
+  const candidates = [];
 
   for (const relativePath of manifest?.dependencyRootsRelative || []) {
     candidates.push(path.resolve(projectRoot, relativePath));
+  }
+
+  let current = projectRoot;
+  while (true) {
+    candidates.push(path.join(current, 'node_modules'));
+    if (repoBoundary && current === repoBoundary) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
   }
 
   const existing = candidates.filter((entry) => fs.existsSync(entry));
@@ -353,7 +380,10 @@ export function generateStandaloneOutput(options: StandaloneOutputOptions): void
     frameworkRuntimeRoot,
   };
 
-  const rebasedServerManifest = rewriteManifestValue(serverManifest, rewriteContext) as ServerManifest;
+  const rebasedServerManifest = rewriteManifestValue(
+    serverManifest,
+    rewriteContext
+  ) as ServerManifest;
   writeJsonFile(path.join(vistaDir, 'server', 'server-manifest.json'), rebasedServerManifest);
 
   const manifestFiles = [
@@ -383,7 +413,9 @@ export function generateStandaloneOutput(options: StandaloneOutputOptions): void
     generatedAt: new Date().toISOString(),
     runtimeRootRelative: path.relative(cwd, runtimeProjectRoot).replace(/\\/g, '/'),
     frameworkRuntimeRelative: path.relative(cwd, frameworkRuntimeRoot).replace(/\\/g, '/'),
-    standaloneServerRelative: path.relative(cwd, path.join(standaloneDir, 'server.js')).replace(/\\/g, '/'),
+    standaloneServerRelative: path
+      .relative(cwd, path.join(standaloneDir, 'server.js'))
+      .replace(/\\/g, '/'),
     fileTraceRelative: path.relative(cwd, fileTracePath).replace(/\\/g, '/'),
     dependencyRootsRelative: [],
   };

--- a/packages/vista/src/server/rsc-engine.ts
+++ b/packages/vista/src/server/rsc-engine.ts
@@ -217,16 +217,15 @@ function parseRevalidationHeader(rawValue: string | null): string[] {
 
   try {
     const parsed = JSON.parse(rawValue);
-    return Array.isArray(parsed) ? parsed.map((entry) => String(entry || '').trim()).filter(Boolean) : [];
+    return Array.isArray(parsed)
+      ? parsed.map((entry) => String(entry || '').trim()).filter(Boolean)
+      : [];
   } catch {
     return [];
   }
 }
 
-function applyUpstreamRevalidations(
-  upstream: Response,
-  vistaDirRoot: string
-): void {
+function applyUpstreamRevalidations(upstream: Response, vistaDirRoot: string): void {
   const revalidatedPaths = parseRevalidationHeader(
     upstream.headers.get('x-vista-revalidated-paths')
   );
@@ -235,9 +234,7 @@ function applyUpstreamRevalidations(
     removeStaticArtifacts(vistaDirRoot, urlPath);
   }
 
-  const revalidatedTags = parseRevalidationHeader(
-    upstream.headers.get('x-vista-revalidated-tags')
-  );
+  const revalidatedTags = parseRevalidationHeader(upstream.headers.get('x-vista-revalidated-tags'));
   for (const tag of revalidatedTags) {
     const affectedPaths = invalidateCachedPagesByTag(tag);
     for (const urlPath of affectedPaths) {
@@ -293,7 +290,9 @@ function setupTypeScriptRuntime(cwd: string): void {
   try {
     const swcRegisterPath = resolveFromWorkspace('@swc-node/register/register', cwd);
     const typescriptPath = resolveFromWorkspace('typescript', cwd);
-    const { register } = require(swcRegisterPath) as { register: (options?: Record<string, any>) => void };
+    const { register } = require(swcRegisterPath) as {
+      register: (options?: Record<string, any>) => void;
+    };
     const ts = require(typescriptPath) as typeof import('typescript');
     register({
       module: ts.ModuleKind.CommonJS,
@@ -436,9 +435,7 @@ function findChunkFiles(cwd: string, isDev: boolean): string[] {
 
   // In dev, avoid loading stale production artifacts left from a previous build.
   // Production chunks end with a hash suffix like `main-1a2b3c4d.js`.
-  const normalizedFiles = isDev
-    ? files.filter((name) => !/-[0-9a-f]{8,}\.js$/i.test(name))
-    : files;
+  const normalizedFiles = isDev ? files.filter((name) => !/-[0-9a-f]{8,}\.js$/i.test(name)) : files;
 
   // Load webpack runtime first, then framework, then the rest alphabetically.
   // This ensures the chunk registry (__webpack_require__) is available before
@@ -478,7 +475,10 @@ function normalizeSSRManifest(manifest: SSRManifest): SSRManifest {
         const decoded = decodeURI(key);
         if (decoded !== key) {
           aliasEntries.push([decoded, exportsMap]);
-          aliasEntries.push([decoded.endsWith('#') ? decoded.slice(0, -1) : `${decoded}#`, exportsMap]);
+          aliasEntries.push([
+            decoded.endsWith('#') ? decoded.slice(0, -1) : `${decoded}#`,
+            exportsMap,
+          ]);
         }
       } catch {
         // ignore decode failures
@@ -487,7 +487,10 @@ function normalizeSSRManifest(manifest: SSRManifest): SSRManifest {
         const encoded = encodeURI(key);
         if (encoded !== key) {
           aliasEntries.push([encoded, exportsMap]);
-          aliasEntries.push([encoded.endsWith('#') ? encoded.slice(0, -1) : `${encoded}#`, exportsMap]);
+          aliasEntries.push([
+            encoded.endsWith('#') ? encoded.slice(0, -1) : `${encoded}#`,
+            exportsMap,
+          ]);
         }
       } catch {
         // ignore encode failures
@@ -918,11 +921,7 @@ async function handleApiRoute(
   }
 }
 
-function spawnUpstream(
-  cwd: string,
-  runtimeRoot: string,
-  upstreamPort: number
-) {
+function spawnUpstream(cwd: string, runtimeRoot: string, upstreamPort: number) {
   const upstreamScript = path.join(__dirname, 'rsc-upstream.js');
   try {
     return {
@@ -1629,7 +1628,10 @@ export function startRSCServer(options: RSCEngineOptions = {}): void {
   const proxyRSCRequest = async (req: express.Request, res: express.Response) => {
     if (isDev && options.compiler) {
       if (clientCompileState === 'compiling') {
-        res.status(503).type('text/plain').send('[vista] Client bundle is compiling. Retry shortly.');
+        res
+          .status(503)
+          .type('text/plain')
+          .send('[vista] Client bundle is compiling. Retry shortly.');
         return;
       }
       if (clientCompileState === 'error') {
@@ -1688,10 +1690,8 @@ export function startRSCServer(options: RSCEngineOptions = {}): void {
     }
   };
 
-  app.get('/rsc*', proxyRSCRequest);
-  app.get('/_rsc*', proxyRSCRequest);
-  app.post('/rsc*', proxyRSCRequest);
-  app.post('/_rsc*', proxyRSCRequest);
+  app.get(/^\/(?:_rsc|rsc)(?:\/.*)?$/, proxyRSCRequest);
+  app.post(/^\/(?:_rsc|rsc)(?:\/.*)?$/, proxyRSCRequest);
 
   // -------------------------------------------------------------------
   // User middleware (middleware.ts at project root)
@@ -1736,416 +1736,416 @@ export function startRSCServer(options: RSCEngineOptions = {}): void {
         urlPath: req.path,
       },
       async () => {
-
-    // ======================================================================
-    // Structure validation gate (strict-block in dev)
-    // ======================================================================
-    if (
-      isDev &&
-      structureConfig.enabled &&
-      structureConfig.mode === 'strict' &&
-      currentStructureState?.state === 'error'
-    ) {
-      const overlayMessage = formatIssuesForOverlay(
-        currentStructureState,
-        structureConfig.includeWarningsInOverlay
-      );
-      const errorInfo = {
-        type: 'build' as const,
-        message: `Structure Validation Failed\n\n${overlayMessage}`,
-      };
-      res
-        .status(500)
-        .type('text/html')
-        .send(renderErrorHTML([errorInfo]));
-      return;
-    }
-
-    if (isDev && options.compiler) {
-      if (clientCompileState === 'compiling') {
-        res.status(503).type('text/html').send(renderCompilePendingHTML());
-        return;
-      }
-      if (clientCompileState === 'error') {
-        const errorInfos = (clientCompileErrors.length > 0
-          ? clientCompileErrors
-          : ['Unknown client build error.']
-        ).map((message) => ({ type: 'build' as const, message }));
-        res.status(500).type('text/html').send(renderErrorHTML(errorInfos));
-        return;
-      }
-    }
-
-    const routeHandlerPath = resolveLegacyRouteHandlerPath(runtimeRoot, req.path);
-    if (routeHandlerPath) {
-      try {
-        await runLegacyApiRoute({
-          req,
-          res,
-          apiPath: routeHandlerPath,
-          isDev,
-        });
-        return;
-      } catch (error) {
-        console.error('[vista:rsc] Route handler error:', error);
-        res.status(500).json({ error: 'Internal Server Error' });
-        return;
-      }
-    }
-
-    if (req.path.startsWith('/api/')) {
-      await handleApiRoute(req, res, runtimeRoot, isDev, typedApiConfig);
-      return;
-    }
-
-    const currentRoute = matchRoute(req.path, serverManifest.routes);
-    setCurrentSegmentConfig(currentRoute?.segmentConfig);
-
-    // ==================================================================
-    // Static / ISR Cache Check
-    // ==================================================================
-    // Before dynamic rendering, check if we have a pre-rendered page.
-    // For ISR pages whose revalidate window has expired, serve the stale
-    // cached version immediately and kick off background revalidation.
-    // ==================================================================
-    if (!isDev) {
-      const cached = getCachedPage(req.path);
-      if (cached.page) {
-        if (cached.stale) {
-          // ISR: serve stale page immediately, revalidate in background
-          const route = currentRoute;
-          if (route && !isRevalidating(req.path)) {
-            const urlPath = req.path;
-            // Fire-and-forget background revalidation
-            revalidatePath(urlPath, route, undefined, runtimeRoot, vistaDirRoot).catch((err) => {
-              console.error('[vista:isr] Background revalidation error:', err);
-            });
-          }
-        }
-        const pprRequestMode = resolvePprRequestMode({
-          headerValue: req.headers['x-vista-prerender'],
-          queryValue: (req.query as any)?.__vista_prerender,
-        });
-        const servePprShell = pprRequestMode === 'shell' && Boolean(cached.page.shellHtml);
-        const responseHtml = servePprShell ? cached.page.shellHtml! : cached.page.html;
-        res
-          .status(200)
-          .type('text/html')
-          .setHeader('X-Vista-Cache', cached.stale ? 'STALE' : 'HIT');
-        if (cached.page.ppr?.enabled) {
-          const responseMode =
-            pprRequestMode === 'resume' ? 'RESUME' : servePprShell ? 'SHELL' : 'PPR';
-          res.setHeader('X-Vista-Prerender', responseMode);
-          res.setHeader('X-Vista-Prerender-Resume', cached.page.ppr.resumePath);
-          res.setHeader('X-Vista-Prerender-Strategy', cached.page.ppr.strategy);
-          res.setHeader(
-            'Vary',
-            appendVaryHeader(res.getHeader('Vary'), 'x-vista-prerender')
+        // ======================================================================
+        // Structure validation gate (strict-block in dev)
+        // ======================================================================
+        if (
+          isDev &&
+          structureConfig.enabled &&
+          structureConfig.mode === 'strict' &&
+          currentStructureState?.state === 'error'
+        ) {
+          const overlayMessage = formatIssuesForOverlay(
+            currentStructureState,
+            structureConfig.includeWarningsInOverlay
           );
+          const errorInfo = {
+            type: 'build' as const,
+            message: `Structure Validation Failed\n\n${overlayMessage}`,
+          };
+          res
+            .status(500)
+            .type('text/html')
+            .send(renderErrorHTML([errorInfo]));
+          return;
         }
-        res.setHeader('X-Vista-Route-Runtime', currentRoute?.segmentConfig.runtime ?? 'nodejs');
-        res.send(responseHtml);
-        return;
-      }
-    }
 
-    if (upstreamUnavailableReason) {
-      res.status(503).type('text/plain').send(getUpstreamUnavailableMessage());
-      return;
-    }
+        if (isDev && options.compiler) {
+          if (clientCompileState === 'compiling') {
+            res.status(503).type('text/html').send(renderCompilePendingHTML());
+            return;
+          }
+          if (clientCompileState === 'error') {
+            const errorInfos = (
+              clientCompileErrors.length > 0 ? clientCompileErrors : ['Unknown client build error.']
+            ).map((message) => ({ type: 'build' as const, message }));
+            res.status(500).type('text/html').send(renderErrorHTML(errorInfos));
+            return;
+          }
+        }
 
-    // ==================================================================
-    // Flight-Based SSR Path
-    // ==================================================================
-    // If the Flight SSR client + SSR manifest are available, render pages
-    // by fetching the Flight stream from upstream and using
-    // renderToPipeableStream for streaming HTML with proper hydration.
-    // Falls back to legacy renderToString if Flight SSR is unavailable.
-    // ==================================================================
-
-    if (useFlightSSR) {
-      try {
-        if (isDev && resolvedSSRManifestPath && fs.existsSync(resolvedSSRManifestPath)) {
+        const routeHandlerPath = resolveLegacyRouteHandlerPath(runtimeRoot, req.path);
+        if (routeHandlerPath) {
           try {
-            ssrManifest = loadSSRManifestFromDisk(resolvedSSRManifestPath);
-          } catch {
-            // Manifest may be mid-write during compilation; keep the last good in-memory copy.
+            await runLegacyApiRoute({
+              req,
+              res,
+              apiPath: routeHandlerPath,
+              isDev,
+            });
+            return;
+          } catch (error) {
+            console.error('[vista:rsc] Route handler error:', error);
+            res.status(500).json({ error: 'Internal Server Error' });
+            return;
           }
         }
 
-        // Metadata extraction: still done locally so we have <head> content
-        const rootLayout = resolveRootLayout(runtimeRoot, isDev);
-        const route = currentRoute;
-
-        let metadataHtml = '';
-        if (route) {
-          if (isDev) {
-            clearProjectRequireCache(runtimeRoot);
-          }
-          const PageModule = require(route.pagePath);
-          let metadata: any = { ...(rootLayout.metadata || {}) };
-          if (PageModule.metadata) {
-            metadata = { ...metadata, ...PageModule.metadata };
-          }
-          if (typeof PageModule.generateMetadata === 'function') {
-            const params = extractParams(req.path, route);
-            const searchParams = Object.fromEntries(
-              new URLSearchParams(req.query as any).entries()
-            );
-            const dynamicMeta = await PageModule.generateMetadata(
-              { params, searchParams },
-              metadata
-            );
-            metadata = { ...metadata, ...dynamicMeta };
-          }
-          const { generateMetadataHtml } = require('../metadata/generate');
-          metadataHtml = metadata ? generateMetadataHtml(metadata) : '';
+        if (req.path.startsWith('/api/')) {
+          await handleApiRoute(req, res, runtimeRoot, isDev, typedApiConfig);
+          return;
         }
 
-        // Render the page via Flight stream → SSR
-        await renderFlightToHTMLStream(
-          upstreamOrigin,
-          req.path,
-          req.query ? new URLSearchParams(req.query as any).toString() : '',
-          metadataHtml,
-          findChunkFiles(cwd, isDev),
-          rootLayout.mode,
-          flightSSRClient!,
-          ssrManifest!,
-          res,
-          isDev
-        );
-        return;
-      } catch (flightError: any) {
-        if (flightError?.name === 'NotFoundError' && !res.headersSent) {
+        const currentRoute = matchRoute(req.path, serverManifest.routes);
+        setCurrentSegmentConfig(currentRoute?.segmentConfig);
+
+        // ==================================================================
+        // Static / ISR Cache Check
+        // ==================================================================
+        // Before dynamic rendering, check if we have a pre-rendered page.
+        // For ISR pages whose revalidate window has expired, serve the stale
+        // cached version immediately and kick off background revalidation.
+        // ==================================================================
+        if (!isDev) {
+          const cached = getCachedPage(req.path);
+          if (cached.page) {
+            if (cached.stale) {
+              // ISR: serve stale page immediately, revalidate in background
+              const route = currentRoute;
+              if (route && !isRevalidating(req.path)) {
+                const urlPath = req.path;
+                // Fire-and-forget background revalidation
+                revalidatePath(urlPath, route, undefined, runtimeRoot, vistaDirRoot).catch(
+                  (err) => {
+                    console.error('[vista:isr] Background revalidation error:', err);
+                  }
+                );
+              }
+            }
+            const pprRequestMode = resolvePprRequestMode({
+              headerValue: req.headers['x-vista-prerender'],
+              queryValue: (req.query as any)?.__vista_prerender,
+            });
+            const servePprShell = pprRequestMode === 'shell' && Boolean(cached.page.shellHtml);
+            const responseHtml = servePprShell ? cached.page.shellHtml! : cached.page.html;
+            res
+              .status(200)
+              .type('text/html')
+              .setHeader('X-Vista-Cache', cached.stale ? 'STALE' : 'HIT');
+            if (cached.page.ppr?.enabled) {
+              const responseMode =
+                pprRequestMode === 'resume' ? 'RESUME' : servePprShell ? 'SHELL' : 'PPR';
+              res.setHeader('X-Vista-Prerender', responseMode);
+              res.setHeader('X-Vista-Prerender-Resume', cached.page.ppr.resumePath);
+              res.setHeader('X-Vista-Prerender-Strategy', cached.page.ppr.strategy);
+              res.setHeader('Vary', appendVaryHeader(res.getHeader('Vary'), 'x-vista-prerender'));
+            }
+            res.setHeader('X-Vista-Route-Runtime', currentRoute?.segmentConfig.runtime ?? 'nodejs');
+            res.send(responseHtml);
+            return;
+          }
+        }
+
+        if (upstreamUnavailableReason) {
+          res.status(503).type('text/plain').send(getUpstreamUnavailableMessage());
+          return;
+        }
+
+        // ==================================================================
+        // Flight-Based SSR Path
+        // ==================================================================
+        // If the Flight SSR client + SSR manifest are available, render pages
+        // by fetching the Flight stream from upstream and using
+        // renderToPipeableStream for streaming HTML with proper hydration.
+        // Falls back to legacy renderToString if Flight SSR is unavailable.
+        // ==================================================================
+
+        if (useFlightSSR) {
           try {
+            if (isDev && resolvedSSRManifestPath && fs.existsSync(resolvedSSRManifestPath)) {
+              try {
+                ssrManifest = loadSSRManifestFromDisk(resolvedSSRManifestPath);
+              } catch {
+                // Manifest may be mid-write during compilation; keep the last good in-memory copy.
+              }
+            }
+
+            // Metadata extraction: still done locally so we have <head> content
             const rootLayout = resolveRootLayout(runtimeRoot, isDev);
             const route = currentRoute;
+
+            let metadataHtml = '';
             if (route) {
-              const segmentNotFoundPath = resolveNearestSegmentNotFoundPath(
-                path.join(runtimeRoot, 'app'),
-                route.routeDir
-              );
-              if (segmentNotFoundPath) {
+              if (isDev) {
+                clearProjectRequireCache(runtimeRoot);
+              }
+              const PageModule = require(route.pagePath);
+              let metadata: any = { ...(rootLayout.metadata || {}) };
+              if (PageModule.metadata) {
+                metadata = { ...metadata, ...PageModule.metadata };
+              }
+              if (typeof PageModule.generateMetadata === 'function') {
                 const params = extractParams(req.path, route);
                 const searchParams = Object.fromEntries(
                   new URLSearchParams(req.query as any).entries()
                 );
-                const notFoundResult = await createRouteElement(
-                  {
-                    ...route,
-                    pagePath: segmentNotFoundPath,
-                  },
-                  { params, searchParams, req },
-                  isDev,
-                  rootLayout,
-                  runtimeRoot,
-                  { disableParallelSlots: true }
+                const dynamicMeta = await PageModule.generateMetadata(
+                  { params, searchParams },
+                  metadata
                 );
-                const html = renderToString(notFoundResult.element);
-                const { generateMetadataHtml } = require('../metadata/generate');
-                const metadataHtml = notFoundResult.metadata
-                  ? generateMetadataHtml(notFoundResult.metadata)
-                  : '';
-                res
-                  .status(404)
-                  .type('text/html')
-                  .send(
-                    createHtmlDocument(
-                      html,
-                      metadataHtml,
-                      findChunkFiles(cwd, isDev),
-                      notFoundResult.rootMode
-                    )
+                metadata = { ...metadata, ...dynamicMeta };
+              }
+              const { generateMetadataHtml } = require('../metadata/generate');
+              metadataHtml = metadata ? generateMetadataHtml(metadata) : '';
+            }
+
+            // Render the page via Flight stream → SSR
+            await renderFlightToHTMLStream(
+              upstreamOrigin,
+              req.path,
+              req.query ? new URLSearchParams(req.query as any).toString() : '',
+              metadataHtml,
+              findChunkFiles(cwd, isDev),
+              rootLayout.mode,
+              flightSSRClient!,
+              ssrManifest!,
+              res,
+              isDev
+            );
+            return;
+          } catch (flightError: any) {
+            if (flightError?.name === 'NotFoundError' && !res.headersSent) {
+              try {
+                const rootLayout = resolveRootLayout(runtimeRoot, isDev);
+                const route = currentRoute;
+                if (route) {
+                  const segmentNotFoundPath = resolveNearestSegmentNotFoundPath(
+                    path.join(runtimeRoot, 'app'),
+                    route.routeDir
                   );
-                return;
+                  if (segmentNotFoundPath) {
+                    const params = extractParams(req.path, route);
+                    const searchParams = Object.fromEntries(
+                      new URLSearchParams(req.query as any).entries()
+                    );
+                    const notFoundResult = await createRouteElement(
+                      {
+                        ...route,
+                        pagePath: segmentNotFoundPath,
+                      },
+                      { params, searchParams, req },
+                      isDev,
+                      rootLayout,
+                      runtimeRoot,
+                      { disableParallelSlots: true }
+                    );
+                    const html = renderToString(notFoundResult.element);
+                    const { generateMetadataHtml } = require('../metadata/generate');
+                    const metadataHtml = notFoundResult.metadata
+                      ? generateMetadataHtml(notFoundResult.metadata)
+                      : '';
+                    res
+                      .status(404)
+                      .type('text/html')
+                      .send(
+                        createHtmlDocument(
+                          html,
+                          metadataHtml,
+                          findChunkFiles(cwd, isDev),
+                          notFoundResult.rootMode
+                        )
+                      );
+                    return;
+                  }
+                }
+              } catch (notFoundError) {
+                console.error(
+                  '[vista:rsc] Failed to render segment not-found fallback:',
+                  notFoundError
+                );
               }
             }
-          } catch (notFoundError) {
-            console.error('[vista:rsc] Failed to render segment not-found fallback:', notFoundError);
+
+            console.error('[vista:rsc] Flight SSR failed:', flightError.message);
+
+            // If headers haven't been sent yet, show the error overlay directly.
+            // This is much better than falling through to legacy renderToString,
+            // which will likely hit the same error (e.g. useState in a server component).
+            if (isDev && !res.headersSent) {
+              const errorInfo = {
+                type: 'runtime' as const,
+                message: flightError.message || 'Flight SSR Error',
+                stack: flightError.stack,
+              };
+              res.status(500).send(renderErrorHTML([errorInfo]));
+              return;
+            }
+
+            // If headers were already sent (stream was partially flushed),
+            // we can't change the status code, but we can inject an error
+            // overlay script at the end of the stream.
+            if (isDev && res.headersSent) {
+              try {
+                const errMsg = (flightError.message || 'Flight SSR Error')
+                  .replace(/'/g, "\\'")
+                  .replace(/\n/g, '\\n');
+                res.write(
+                  `<script>document.body.innerHTML='';document.body.style.background='#1a1a2e';document.body.style.color='#ff6b6b';document.body.style.fontFamily='monospace';document.body.style.padding='40px';document.body.innerHTML='<h2 style="color:#ff6b6b">\\u26a0 Server Error</h2><pre style="white-space:pre-wrap;color:#ffa07a">${errMsg}</pre>';</script>`
+                );
+                res.end();
+              } catch {
+                res.end();
+              }
+              return;
+            }
           }
         }
 
-        console.error('[vista:rsc] Flight SSR failed:', flightError.message);
+        // ==================================================================
+        // Legacy Fallback: Direct renderToString
+        // ==================================================================
+        // Used when Flight SSR is unavailable or fails. This path does NOT
+        // go through the Flight protocol — it requires page modules directly
+        // and renders them with renderToString (synchronous, no streaming).
+        // ==================================================================
 
-        // If headers haven't been sent yet, show the error overlay directly.
-        // This is much better than falling through to legacy renderToString,
-        // which will likely hit the same error (e.g. useState in a server component).
-        if (isDev && !res.headersSent) {
-          const errorInfo = {
-            type: 'runtime' as const,
-            message: flightError.message || 'Flight SSR Error',
-            stack: flightError.stack,
-          };
-          res.status(500).send(renderErrorHTML([errorInfo]));
-          return;
-        }
-
-        // If headers were already sent (stream was partially flushed),
-        // we can't change the status code, but we can inject an error
-        // overlay script at the end of the stream.
-        if (isDev && res.headersSent) {
-          try {
-            const errMsg = (flightError.message || 'Flight SSR Error')
-              .replace(/'/g, "\\'")
-              .replace(/\n/g, '\\n');
-            res.write(
-              `<script>document.body.innerHTML='';document.body.style.background='#1a1a2e';document.body.style.color='#ff6b6b';document.body.style.fontFamily='monospace';document.body.style.padding='40px';document.body.innerHTML='<h2 style="color:#ff6b6b">\\u26a0 Server Error</h2><pre style="white-space:pre-wrap;color:#ffa07a">${errMsg}</pre>';</script>`
-            );
-            res.end();
-          } catch {
-            res.end();
-          }
-          return;
-        }
-      }
-    }
-
-    // ==================================================================
-    // Legacy Fallback: Direct renderToString
-    // ==================================================================
-    // Used when Flight SSR is unavailable or fails. This path does NOT
-    // go through the Flight protocol — it requires page modules directly
-    // and renders them with renderToString (synchronous, no streaming).
-    // ==================================================================
-
-    try {
-      // Check upstream availability for the legacy path
-      await withTimeout(
-        `${upstreamOrigin}/rsc/`,
-        { headers: { Accept: 'text/x-component' } },
-        3000
-      );
-    } catch (error) {
-      res.status(503).type('text/plain').send(getUpstreamUnavailableMessage());
-      return;
-    }
-
-    try {
-      const rootLayout = resolveRootLayout(runtimeRoot, isDev);
-      const route = currentRoute;
-      setCurrentSegmentConfig(route?.segmentConfig);
-      if (!route) {
-        const resolvedNotFound = resolveNotFoundComponent(runtimeRoot, rootLayout, isDev);
-        if (resolvedNotFound) {
-          const notFoundElement = React.createElement(resolvedNotFound.component, {
-            params: {},
-            searchParams: {},
-          });
-          const wrapped = React.createElement(
-            rootLayout.component,
-            { params: {}, searchParams: {} },
-            notFoundElement
+        try {
+          // Check upstream availability for the legacy path
+          await withTimeout(
+            `${upstreamOrigin}/rsc/`,
+            { headers: { Accept: 'text/x-component' } },
+            3000
           );
-          const html = renderToString(wrapped);
-          res
-            .status(404)
-            .type('text/html')
-            .send(createHtmlDocument(html, '', findChunkFiles(cwd, isDev), rootLayout.mode));
+        } catch (error) {
+          res.status(503).type('text/plain').send(getUpstreamUnavailableMessage());
           return;
         }
-        res.status(404).type('text/html').send(getStyledNotFoundHTML());
-        return;
-      }
 
-      const params = extractParams(req.path, route);
-      const searchParams = Object.fromEntries(new URLSearchParams(req.query as any).entries());
-      const { element, metadata, rootMode } = await createRouteElement(
-        route,
-        { params, searchParams, req },
-        isDev,
-        rootLayout,
-        runtimeRoot
-      );
-      const appHtml = renderToString(element);
-      const { generateMetadataHtml } = require('../metadata/generate');
-      const metadataHtml = metadata ? generateMetadataHtml(metadata) : '';
-      res
-        .status(200)
-        .type('text/html')
-        .send(createHtmlDocument(appHtml, metadataHtml, findChunkFiles(cwd, isDev), rootMode));
-    } catch (error: any) {
-      if (error?.name === 'NotFoundError') {
         try {
           const rootLayout = resolveRootLayout(runtimeRoot, isDev);
           const route = currentRoute;
           setCurrentSegmentConfig(route?.segmentConfig);
-          if (route) {
-            const segmentNotFoundPath = resolveNearestSegmentNotFoundPath(
-              path.join(runtimeRoot, 'app'),
-              route.routeDir
-            );
-            if (segmentNotFoundPath) {
-              const params = extractParams(req.path, route);
-              const searchParams = Object.fromEntries(
-                new URLSearchParams(req.query as any).entries()
+          if (!route) {
+            const resolvedNotFound = resolveNotFoundComponent(runtimeRoot, rootLayout, isDev);
+            if (resolvedNotFound) {
+              const notFoundElement = React.createElement(resolvedNotFound.component, {
+                params: {},
+                searchParams: {},
+              });
+              const wrapped = React.createElement(
+                rootLayout.component,
+                { params: {}, searchParams: {} },
+                notFoundElement
               );
-              const notFoundResult = await createRouteElement(
-                {
-                  ...route,
-                  pagePath: segmentNotFoundPath,
-                },
-                { params, searchParams, req },
-                isDev,
-                rootLayout,
-                runtimeRoot,
-                { disableParallelSlots: true }
-              );
-              const html = renderToString(notFoundResult.element);
-              const { generateMetadataHtml } = require('../metadata/generate');
-              const metadataHtml = notFoundResult.metadata
-                ? generateMetadataHtml(notFoundResult.metadata)
-                : '';
+              const html = renderToString(wrapped);
               res
                 .status(404)
                 .type('text/html')
-                .send(
-                  createHtmlDocument(
-                    html,
-                    metadataHtml,
-                    findChunkFiles(cwd, isDev),
-                    notFoundResult.rootMode
-                  )
-                );
+                .send(createHtmlDocument(html, '', findChunkFiles(cwd, isDev), rootLayout.mode));
               return;
             }
-          }
-          const resolvedNotFound = resolveNotFoundComponent(runtimeRoot, rootLayout, isDev);
-          if (resolvedNotFound) {
-            const notFoundElement = React.createElement(resolvedNotFound.component, {
-              params: {},
-              searchParams: {},
-            });
-            const wrapped = React.createElement(
-              rootLayout.component,
-              { params: {}, searchParams: {} },
-              notFoundElement
-            );
-            const html = renderToString(wrapped);
-            res
-              .status(404)
-              .type('text/html')
-              .send(createHtmlDocument(html, '', findChunkFiles(cwd, isDev), rootLayout.mode));
+            res.status(404).type('text/html').send(getStyledNotFoundHTML());
             return;
           }
-          res.status(404).type('text/html').send(getStyledNotFoundHTML());
-          return;
-        } catch (notFoundError) {
-          console.error('[vista:rsc] Failed to render NotFoundError fallback:', notFoundError);
+
+          const params = extractParams(req.path, route);
+          const searchParams = Object.fromEntries(new URLSearchParams(req.query as any).entries());
+          const { element, metadata, rootMode } = await createRouteElement(
+            route,
+            { params, searchParams, req },
+            isDev,
+            rootLayout,
+            runtimeRoot
+          );
+          const appHtml = renderToString(element);
+          const { generateMetadataHtml } = require('../metadata/generate');
+          const metadataHtml = metadata ? generateMetadataHtml(metadata) : '';
+          res
+            .status(200)
+            .type('text/html')
+            .send(createHtmlDocument(appHtml, metadataHtml, findChunkFiles(cwd, isDev), rootMode));
+        } catch (error: any) {
+          if (error?.name === 'NotFoundError') {
+            try {
+              const rootLayout = resolveRootLayout(runtimeRoot, isDev);
+              const route = currentRoute;
+              setCurrentSegmentConfig(route?.segmentConfig);
+              if (route) {
+                const segmentNotFoundPath = resolveNearestSegmentNotFoundPath(
+                  path.join(runtimeRoot, 'app'),
+                  route.routeDir
+                );
+                if (segmentNotFoundPath) {
+                  const params = extractParams(req.path, route);
+                  const searchParams = Object.fromEntries(
+                    new URLSearchParams(req.query as any).entries()
+                  );
+                  const notFoundResult = await createRouteElement(
+                    {
+                      ...route,
+                      pagePath: segmentNotFoundPath,
+                    },
+                    { params, searchParams, req },
+                    isDev,
+                    rootLayout,
+                    runtimeRoot,
+                    { disableParallelSlots: true }
+                  );
+                  const html = renderToString(notFoundResult.element);
+                  const { generateMetadataHtml } = require('../metadata/generate');
+                  const metadataHtml = notFoundResult.metadata
+                    ? generateMetadataHtml(notFoundResult.metadata)
+                    : '';
+                  res
+                    .status(404)
+                    .type('text/html')
+                    .send(
+                      createHtmlDocument(
+                        html,
+                        metadataHtml,
+                        findChunkFiles(cwd, isDev),
+                        notFoundResult.rootMode
+                      )
+                    );
+                  return;
+                }
+              }
+              const resolvedNotFound = resolveNotFoundComponent(runtimeRoot, rootLayout, isDev);
+              if (resolvedNotFound) {
+                const notFoundElement = React.createElement(resolvedNotFound.component, {
+                  params: {},
+                  searchParams: {},
+                });
+                const wrapped = React.createElement(
+                  rootLayout.component,
+                  { params: {}, searchParams: {} },
+                  notFoundElement
+                );
+                const html = renderToString(wrapped);
+                res
+                  .status(404)
+                  .type('text/html')
+                  .send(createHtmlDocument(html, '', findChunkFiles(cwd, isDev), rootLayout.mode));
+                return;
+              }
+              res.status(404).type('text/html').send(getStyledNotFoundHTML());
+              return;
+            } catch (notFoundError) {
+              console.error('[vista:rsc] Failed to render NotFoundError fallback:', notFoundError);
+            }
+          }
+          console.error('[vista:rsc] Render error:', error);
+          if (isDev) {
+            const errorInfo = {
+              type: 'runtime' as const,
+              message: error.message || 'Unknown Server Error',
+              stack: error.stack,
+            };
+            res.status(500).send(renderErrorHTML([errorInfo]));
+          } else {
+            res.status(500).send('<h1>Internal Server Error</h1>');
+          }
         }
-      }
-      console.error('[vista:rsc] Render error:', error);
-      if (isDev) {
-        const errorInfo = {
-          type: 'runtime' as const,
-          message: error.message || 'Unknown Server Error',
-          stack: error.stack,
-        };
-        res.status(500).send(renderErrorHTML([errorInfo]));
-      } else {
-        res.status(500).send('<h1>Internal Server Error</h1>');
-      }
-    }
       }
     );
   });

--- a/packages/vista/src/server/rsc-upstream.ts
+++ b/packages/vista/src/server/rsc-upstream.ts
@@ -16,7 +16,7 @@ import {
   runWithRequestContext,
   setCurrentSegmentConfig,
 } from './request-context';
-import { resolveRegisteredServerReference } from './runtime-actions';
+import { resolveRegisteredServerReference, setRegisterServerReference } from './runtime-actions';
 import {
   resolveConventionModule,
   resolveDirectoryChain,
@@ -52,6 +52,13 @@ function getRouteSuspense() {
 }
 
 const CjsModule = require('module');
+if (process.env.NODE_PATH) {
+  try {
+    CjsModule._initPaths();
+  } catch (_err) {
+    // ignore
+  }
+}
 // Support CSS imports on server runtime
 require.extensions['.css'] = (m: any, filename: string) => {
   if (filename.endsWith('.module.css')) {
@@ -144,7 +151,9 @@ function setupTypeScriptRuntime(cwd: string): void {
   try {
     const swcRegisterPath = resolveFromWorkspace('@swc-node/register/register', cwd);
     const typescriptPath = resolveFromWorkspace('typescript', cwd);
-    const { register } = require(swcRegisterPath) as { register: (options?: Record<string, any>) => void };
+    const { register } = require(swcRegisterPath) as {
+      register: (options?: Record<string, any>) => void;
+    };
     const ts = require(typescriptPath) as typeof import('typescript');
     register({
       module: ts.ModuleKind.CommonJS,
@@ -267,6 +276,14 @@ function installSingleReactResolution(cwd: string): void {
       const subPath = request.slice('react-dom/'.length);
       try {
         return require.resolve(`react-dom/${subPath}`, { paths: [path.dirname(reactDomPath)] });
+      } catch {
+        // fall through
+      }
+    }
+
+    if (request === 'react-server-dom-webpack' || request.startsWith('react-server-dom-webpack/')) {
+      try {
+        return resolveFromWorkspace(request, cwd);
       } catch {
         // fall through
       }
@@ -573,10 +590,7 @@ async function readRawRequestBody(req: express.Request): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
-async function parseMultipartFormData(
-  req: express.Request,
-  rawBody: Buffer
-): Promise<FormData> {
+async function parseMultipartFormData(req: express.Request, rawBody: Buffer): Promise<FormData> {
   const request = new Request(`http://127.0.0.1${req.originalUrl || req.url || '/'}`, {
     method: req.method || 'POST',
     headers: req.headers as Record<string, string>,
@@ -602,6 +616,9 @@ function startUpstream(): void {
 
   const flightServerPath = resolveFromWorkspace('react-server-dom-webpack/server.node', cwd);
   const flightServer = require(flightServerPath) as FlightServerApi;
+  if (typeof flightServer.registerServerReference === 'function') {
+    setRegisterServerReference(flightServer.registerServerReference);
+  }
   installClientLoadHook(runtimeRoot, flightServer.createClientModuleProxy);
   installSegmentFetchPolicyShim();
 
@@ -773,7 +790,9 @@ function startUpstream(): void {
       }) ||
       null;
 
-    const resolvedActionPath = path.resolve(actionEntry.filePath || resolveActionModulePath(actionId));
+    const resolvedActionPath = path.resolve(
+      actionEntry.filePath || resolveActionModulePath(actionId)
+    );
     const routeParams = actionRoute ? extractParams(pathname, actionRoute) : {};
 
     if (isDev) {
@@ -994,8 +1013,7 @@ function startUpstream(): void {
     );
   };
 
-  app.get('/rsc*', handleRSCRequest);
-  app.get('/_rsc*', handleRSCRequest);
+  app.get(/^\/(?:_rsc|rsc)(?:\/.*)?$/, handleRSCRequest);
 
   // -----------------------------------------------------------------------
   // Server Actions — POST handler
@@ -1069,7 +1087,10 @@ function startUpstream(): void {
             const boundAction = await flightServer.decodeAction(formData, flightManifest);
             result = await boundAction();
           } else {
-            const args = (await flightServer.decodeReply(rawBody.toString('utf-8'), flightManifest)) as unknown[];
+            const args = (await flightServer.decodeReply(
+              rawBody.toString('utf-8'),
+              flightManifest
+            )) as unknown[];
             result = await actionFn(...(Array.isArray(args) ? args : [args]));
           }
 
@@ -1105,8 +1126,7 @@ function startUpstream(): void {
     );
   };
 
-  app.post('/rsc*', handleServerAction);
-  app.post('/_rsc*', handleServerAction);
+  app.post(/^\/(?:_rsc|rsc)(?:\/.*)?$/, handleServerAction);
 
   const server = app.listen(port, () => {
     console.log(`[vista:rsc:upstream] Listening on http://127.0.0.1:${port}/rsc`);

--- a/packages/vista/src/server/runtime-actions.ts
+++ b/packages/vista/src/server/runtime-actions.ts
@@ -1,11 +1,15 @@
 import { pathToFileURL } from 'url';
 import path from 'path';
 
-type RegisterServerReferenceFn = (reference: Function, id: string, exportName: string) => void;
+type RegisterServerReferenceFn = (reference: any, id: string, exportName: string | null) => void;
 
 const registeredReferences = new Map<string, Function>();
 
 let cachedRegisterServerReference: RegisterServerReferenceFn | null | undefined;
+
+export function setRegisterServerReference(fn: RegisterServerReferenceFn | null): void {
+  cachedRegisterServerReference = fn;
+}
 
 function getRegisterServerReference(): RegisterServerReferenceFn | null {
   if (cachedRegisterServerReference !== undefined) {
@@ -33,10 +37,12 @@ function normalizeExportName(exportName?: string): string {
 }
 
 function normalizeHint(value: string): string {
-  return String(value || 'action')
-    .trim()
-    .replace(/[^a-zA-Z0-9_$]+/g, '_')
-    .replace(/^_+|_+$/g, '') || 'action';
+  return (
+    String(value || 'action')
+      .trim()
+      .replace(/[^a-zA-Z0-9_$]+/g, '_')
+      .replace(/^_+|_+$/g, '') || 'action'
+  );
 }
 
 function createStableFileUrl(filePath: string): string {
@@ -70,17 +76,15 @@ export function registerInlineServerReference<T extends Function>(
   const normalizedExportName = normalizeExportName(exportName);
   const registerServerReference = getRegisterServerReference();
   if (registerServerReference) {
-    registerServerReference(reference, id, normalizedExportName);
+    const effectiveExportName = id.includes('#') ? null : normalizedExportName;
+    registerServerReference(reference, id, effectiveExportName);
   }
 
   registeredReferences.set(id, reference);
   return reference;
 }
 
-export function registerServerActionModule(
-  moduleExports: unknown,
-  filePath: string
-): unknown {
+export function registerServerActionModule(moduleExports: unknown, filePath: string): unknown {
   if (!moduleExports || typeof moduleExports !== 'object') {
     return moduleExports;
   }

--- a/scripts/test-server-runtime.cjs
+++ b/scripts/test-server-runtime.cjs
@@ -46,54 +46,20 @@ function registerTypeScriptRuntime() {
 
 registerTypeScriptRuntime();
 
-const { runWithRequestContext } = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'request-context.ts'
-));
-const serverApi = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'index.ts'
-));
-const cacheApi = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'cache.ts'
-));
-const actionRuntime = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'runtime-actions.ts'
-));
-const { installModuleCompileHook } = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'module-compile-hook.ts'
-));
-const staticCache = require(path.join(
-  repoRoot,
-  'packages',
-  'vista',
-  'src',
-  'server',
-  'static-cache.ts'
-));
+const { runWithRequestContext } = require(
+  path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'request-context.ts')
+);
+const serverApi = require(path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'index.ts'));
+const cacheApi = require(path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'cache.ts'));
+const actionRuntime = require(
+  path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'runtime-actions.ts')
+);
+const { installModuleCompileHook } = require(
+  path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'module-compile-hook.ts')
+);
+const staticCache = require(
+  path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'static-cache.ts')
+);
 
 function createMockReq(overrides = {}) {
   const headers = { ...(overrides.headers || {}) };
@@ -228,7 +194,7 @@ async function main() {
           )});`,
           "const { readValue } = require('./use-cache-state.js');",
           'exports.readCached = function readCached() {',
-          "  cacheLife(30);",
+          '  cacheLife(30);',
           "  cacheTag('runtime-use-cache');",
           '  return { value: readValue() };',
           '};',
@@ -260,14 +226,14 @@ async function main() {
       fs.writeFileSync(
         inlineModulePath,
         [
-          "const { cacheLife, cacheTag } = require(" +
+          'const { cacheLife, cacheTag } = require(' +
             JSON.stringify(path.join(repoRoot, 'packages', 'vista', 'src', 'server', 'index.ts')) +
             ');',
           "const { readValue } = require('./use-cache-state.js');",
           'exports.readInlineCached = async function readInlineCached() {',
           '  async function loadValue() {',
           "    'use cache';",
-          "    cacheLife(30);",
+          '    cacheLife(30);',
           "    cacheTag('runtime-inline-use-cache');",
           '    return { value: readValue() };',
           '  }',
@@ -372,7 +338,11 @@ async function main() {
       delete require.cache[require.resolve(inlineModulePath)];
       const inlineModule = require(inlineModulePath);
       const inlineAction = inlineModule.buildInlineAction();
-      const inlineActionId = actionRuntime.createInlineServerActionId(inlineModulePath, 0, 'inlineEcho');
+      const inlineActionId = actionRuntime.createInlineServerActionId(
+        inlineModulePath,
+        0,
+        'inlineEcho'
+      );
       const registeredInlineAction = actionRuntime.resolveRegisteredServerReference(inlineActionId);
       if (!registeredInlineAction) {
         console.error('Inline action registration mismatch.');
@@ -385,6 +355,26 @@ async function main() {
         inlineAction,
         'Inline action should be registered through the compile hook'
       );
+
+      // Regression test: custom registrar bridging and id sanitation
+      let capturedCall = null;
+      actionRuntime.setRegisterServerReference((ref, id, exp) => {
+        capturedCall = { ref, id, exp };
+      });
+
+      const dummyAction = async function dummyAction() {};
+      const hashedId = actionRuntime.createInlineServerActionId(inlineModulePath, 1, 'dummyAction');
+      actionRuntime.registerInlineServerReference(dummyAction, hashedId, 'dummyAction');
+
+      assert.ok(capturedCall, 'setRegisterServerReference registrar should be invoked');
+      assert.equal(capturedCall.ref, dummyAction, 'Registrar should receive reference function');
+      assert.equal(capturedCall.id, hashedId, 'Registrar should receive exact action id');
+      assert.equal(
+        capturedCall.exp,
+        null,
+        'Registrar should receive null exportName when id contains hash to avoid duplicate hash suffixes'
+      );
+      actionRuntime.setRegisterServerReference(null);
 
       const exportedModulePath = path.join(tempProject, 'exported-actions.js');
       fs.writeFileSync(


### PR DESCRIPTION
## Description

Resolves the RSC Conformance Failure described in Issue #7 (Item 1).

When inline server actions (e.g. `async function inlineEcho() { 'use server'; ... }`) were defined inside Server Components and passed as props to Client Components (`<ActionProbe action={inlineEcho} />`), React Server DOM Webpack failed serialization with HTTP 500:
```text
Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server".
```

### Root Cause
1. **Missing Reference Registrar Hook**: In `packages/vista/src/server/runtime-actions.ts`, `getRegisterServerReference()` attempted a bare `require('react-server-dom-webpack/server.node')`, which silently failed and fell back to `null`. Without registering the reference function with React Flight's server registrar, React did not attach `$$typeof = Symbol.for('react.server.reference')` and `$$id`.
2. **Duplicate Hash Suffix**: When `registerServerReference(fn, id, exportName)` was invoked, `react-server-dom-webpack` appended `#exportName` to `id` if `exportName` was truthy. Since inline actions already use canonical hashed IDs (e.g. `file:///...#inlineEchobash`), this resulted in corrupted double-hashed IDs.
3. **Standalone Resolution Isolation**: In standalone output mode, `installDependencyRoots` did not halt candidate traversal at the workspace/repo boundary, causing external node_modules to be searched.

### Solution
- **Bridge Flight Registrar**: Added `setRegisterServerReference` in `runtime-actions.ts` and wired `flightServer.registerServerReference` from `rsc-upstream.ts` immediately upon loading Flight server.
- **Sanitize Inline Action IDs**: Sanitized `exportName` to `null` in `registerInlineServerReference` whenever `id` already contains `#`.
- **Repo Boundary Confinement**: Restricted `Module._nodeModulePaths` and candidate traversal in `standalone.ts` to stay within the repository boundary (`.git` / `pnpm-workspace.yaml`).
- **Regression Tests & Docs**:
  - Added unit regression tests in `scripts/test-server-runtime.cjs` verifying registrar bridging, reference attachment, exact ID retention, and `null` exportName for hashed inline IDs.
  - Documented Server Actions in `README.md`.

## Related Issue
Fixes #7 (Item 1: RSC Conformance Failure)

## Verification
- `pnpm test:server-runtime` (PASSED)
- `pnpm test:rsc-conformance` (PASSED - all routes including `/conformance/actions-inline`)
- `pnpm test:vista-output` (PASSED)
- `pnpm test:runtime:platform-gate` (PASSED - 102/102 integrity checks + all gates)
- `pnpm test:integrity` (PASSED)
- Rebuilt package distribution (`packages/vista/dist`)