### PR TITLE
fix:RSC conformance failure fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 .env.development.local
 .env.test.local
 .env.production.local
+
+.tmp

--- a/packages/vista/dist/server/module-compile-hook.js
+++ b/packages/vista/dist/server/module-compile-hook.js
@@ -61,10 +61,11 @@ function createDirectiveError(filename, message) {
 }
 function isProjectModule(filename, roots) {
     const normalized = normalizeModulePath(filename);
-    const matchesRoot = roots.some((root) => {
+    const matchingRoot = roots.find((root) => {
         const rootPrefix = normalizeModulePath(`${root}${path_1.default.sep}`);
         return normalized.startsWith(rootPrefix);
     });
+    const matchesRoot = Boolean(matchingRoot);
     const isStandaloneProjectModule = roots.some((root) => {
         const normalizedRoot = normalizeModulePath(root);
         return (normalizedRoot.includes('/.vista/standalone/') &&
@@ -72,8 +73,9 @@ function isProjectModule(filename, roots) {
     });
     if (!matchesRoot)
         return false;
-    if (normalized.includes('/node_modules/'))
+    if (normalized.includes('/node_modules/') && !normalizeModulePath(matchingRoot).includes('/node_modules/')) {
         return false;
+    }
     if (normalized.includes('/.vista/') && !isStandaloneProjectModule)
         return false;
     if (normalized.includes('/.flash/'))
@@ -86,14 +88,17 @@ function isStringDirectiveStatement(statement, directive) {
             (statement.expression?.type === 'StringLiteral' &&
                 statement.expression?.value === directive)));
 }
+function isFunctionBody(node) {
+    return node?.type === 'BlockStatement' || node?.type === 'FunctionBody';
+}
 function hasServerDirectiveInFunctionLike(node) {
-    return (node?.body?.type === 'BlockStatement' &&
+    return (isFunctionBody(node?.body) &&
         Array.isArray(node.body.stmts) &&
         node.body.stmts.length > 0 &&
         isStringDirectiveStatement(node.body.stmts[0], 'use server'));
 }
 function hasCacheDirectiveInFunctionLike(node) {
-    return (node?.body?.type === 'BlockStatement' &&
+    return (isFunctionBody(node?.body) &&
         Array.isArray(node.body.stmts) &&
         node.body.stmts.length > 0 &&
         isStringDirectiveStatement(node.body.stmts[0], 'use cache'));
@@ -212,7 +217,7 @@ function createRuntimeRequireDeclaration(runtimeIdentifier, runtimeSpecifier) {
     };
 }
 function processFunctionLikeDeclaration(statement, filename, state, nextStatements) {
-    if (statement?.body?.type !== 'BlockStatement') {
+    if (!isFunctionBody(statement?.body)) {
         return false;
     }
     statement.body.stmts = processStatementList(statement.body.stmts || [], filename, state);
@@ -241,11 +246,7 @@ function processStatementList(statements, filename, state) {
             continue;
         }
         if (statement.type === 'ExportDefaultDeclaration' && statement.decl) {
-            if (statement.decl.body?.type === 'BlockStatement') {
-                statement.decl.body.stmts = processStatementList(statement.decl.body.stmts || [], filename, state);
-            }
-            else if ((statement.decl.type === 'FunctionExpression' || statement.decl.type === 'ArrowFunctionExpression') &&
-                statement.decl.body?.type === 'BlockStatement') {
+            if (isFunctionBody(statement.decl.body)) {
                 statement.decl.body.stmts = processStatementList(statement.decl.body.stmts || [], filename, state);
             }
             if ((statement.decl.type === 'FunctionDeclaration' ||
@@ -366,7 +367,7 @@ function processExpression(expression, filename, state, hint = 'action') {
         return expression;
     }
     if (expression.type === 'ArrowFunctionExpression' || expression.type === 'FunctionExpression') {
-        if (expression.body?.type === 'BlockStatement') {
+        if (isFunctionBody(expression.body)) {
             expression.body.stmts = processStatementList(expression.body.stmts || [], filename, state);
         }
         if (hasServerDirectiveInFunctionLike(expression)) {

--- a/packages/vista/dist/server/rsc-upstream.js
+++ b/packages/vista/dist/server/rsc-upstream.js
@@ -482,6 +482,7 @@ function startUpstream() {
     setupTypeScriptRuntime(runtimeRoot);
     const flightServerPath = resolveFromWorkspace('react-server-dom-webpack/server.node', cwd);
     const flightServer = require(flightServerPath);
+    (0, runtime_actions_1.configureServerReferenceRegistration)(flightServer.registerServerReference);
     installClientLoadHook(runtimeRoot, flightServer.createClientModuleProxy);
     (0, fetch_policy_1.installSegmentFetchPolicyShim)();
     const serverManifestPath = path_1.default.join(cwd, constants_1.BUILD_DIR, 'server', 'server-manifest.json');

--- a/packages/vista/dist/server/runtime-actions.d.ts
+++ b/packages/vista/dist/server/runtime-actions.d.ts
@@ -1,5 +1,8 @@
+type RegisterServerReferenceFn = (reference: Function, id: string, exportName: string) => void;
+export declare function configureServerReferenceRegistration(registerServerReference: RegisterServerReferenceFn): void;
 export declare function createExportServerReferenceId(filePath: string, exportName?: string): string;
 export declare function createInlineServerActionId(filePath: string, ordinal: number, hint?: string): string;
 export declare function registerInlineServerReference<T extends Function>(reference: T, id: string, exportName?: string): T;
 export declare function registerServerActionModule(moduleExports: unknown, filePath: string): unknown;
 export declare function resolveRegisteredServerReference(id: string): Function | undefined;
+export {};

--- a/packages/vista/dist/server/runtime-actions.js
+++ b/packages/vista/dist/server/runtime-actions.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.configureServerReferenceRegistration = configureServerReferenceRegistration;
 exports.createExportServerReferenceId = createExportServerReferenceId;
 exports.createInlineServerActionId = createInlineServerActionId;
 exports.registerInlineServerReference = registerInlineServerReference;
@@ -12,6 +13,9 @@ const url_1 = require("url");
 const path_1 = __importDefault(require("path"));
 const registeredReferences = new Map();
 let cachedRegisterServerReference;
+function configureServerReferenceRegistration(registerServerReference) {
+    cachedRegisterServerReference = registerServerReference;
+}
 function getRegisterServerReference() {
     if (cachedRegisterServerReference !== undefined) {
         return cachedRegisterServerReference;

--- a/packages/vista/src/server/module-compile-hook.ts
+++ b/packages/vista/src/server/module-compile-hook.ts
@@ -84,10 +84,11 @@ function createDirectiveError(filename: string, message: string): Error {
 
 function isProjectModule(filename: string, roots: string[]): boolean {
   const normalized = normalizeModulePath(filename);
-  const matchesRoot = roots.some((root) => {
+  const matchingRoot = roots.find((root) => {
     const rootPrefix = normalizeModulePath(`${root}${path.sep}`);
     return normalized.startsWith(rootPrefix);
   });
+  const matchesRoot = Boolean(matchingRoot);
   const isStandaloneProjectModule = roots.some((root) => {
     const normalizedRoot = normalizeModulePath(root);
     return (
@@ -97,7 +98,9 @@ function isProjectModule(filename: string, roots: string[]): boolean {
   });
 
   if (!matchesRoot) return false;
-  if (normalized.includes('/node_modules/')) return false;
+  if (normalized.includes('/node_modules/') && !normalizeModulePath(matchingRoot!).includes('/node_modules/')) {
+    return false;
+  }
   if (normalized.includes('/.vista/') && !isStandaloneProjectModule) return false;
   if (normalized.includes('/.flash/')) return false;
 
@@ -113,9 +116,13 @@ function isStringDirectiveStatement(statement: any, directive: string): boolean 
   );
 }
 
+function isFunctionBody(node: any): boolean {
+  return node?.type === 'BlockStatement' || node?.type === 'FunctionBody';
+}
+
 function hasServerDirectiveInFunctionLike(node: any): boolean {
   return (
-    node?.body?.type === 'BlockStatement' &&
+    isFunctionBody(node?.body) &&
     Array.isArray(node.body.stmts) &&
     node.body.stmts.length > 0 &&
     isStringDirectiveStatement(node.body.stmts[0], 'use server')
@@ -124,7 +131,7 @@ function hasServerDirectiveInFunctionLike(node: any): boolean {
 
 function hasCacheDirectiveInFunctionLike(node: any): boolean {
   return (
-    node?.body?.type === 'BlockStatement' &&
+    isFunctionBody(node?.body) &&
     Array.isArray(node.body.stmts) &&
     node.body.stmts.length > 0 &&
     isStringDirectiveStatement(node.body.stmts[0], 'use cache')
@@ -266,7 +273,7 @@ function processFunctionLikeDeclaration(
   state: InlineTransformState,
   nextStatements: any[]
 ): boolean {
-  if (statement?.body?.type !== 'BlockStatement') {
+  if (!isFunctionBody(statement?.body)) {
     return false;
   }
 
@@ -303,12 +310,7 @@ function processStatementList(statements: any[], filename: string, state: Inline
     }
 
     if (statement.type === 'ExportDefaultDeclaration' && statement.decl) {
-      if (statement.decl.body?.type === 'BlockStatement') {
-        statement.decl.body.stmts = processStatementList(statement.decl.body.stmts || [], filename, state);
-      } else if (
-        (statement.decl.type === 'FunctionExpression' || statement.decl.type === 'ArrowFunctionExpression') &&
-        statement.decl.body?.type === 'BlockStatement'
-      ) {
+      if (isFunctionBody(statement.decl.body)) {
         statement.decl.body.stmts = processStatementList(statement.decl.body.stmts || [], filename, state);
       }
 
@@ -470,7 +472,7 @@ function processExpression(
   }
 
   if (expression.type === 'ArrowFunctionExpression' || expression.type === 'FunctionExpression') {
-    if (expression.body?.type === 'BlockStatement') {
+    if (isFunctionBody(expression.body)) {
       expression.body.stmts = processStatementList(expression.body.stmts || [], filename, state);
     }
 

--- a/packages/vista/src/server/rsc-upstream.ts
+++ b/packages/vista/src/server/rsc-upstream.ts
@@ -16,7 +16,10 @@ import {
   runWithRequestContext,
   setCurrentSegmentConfig,
 } from './request-context';
-import { resolveRegisteredServerReference } from './runtime-actions';
+import {
+  configureServerReferenceRegistration,
+  resolveRegisteredServerReference,
+} from './runtime-actions';
 import {
   resolveConventionModule,
   resolveDirectoryChain,
@@ -602,6 +605,7 @@ function startUpstream(): void {
 
   const flightServerPath = resolveFromWorkspace('react-server-dom-webpack/server.node', cwd);
   const flightServer = require(flightServerPath) as FlightServerApi;
+  configureServerReferenceRegistration(flightServer.registerServerReference);
   installClientLoadHook(runtimeRoot, flightServer.createClientModuleProxy);
   installSegmentFetchPolicyShim();
 

--- a/packages/vista/src/server/runtime-actions.ts
+++ b/packages/vista/src/server/runtime-actions.ts
@@ -7,6 +7,12 @@ const registeredReferences = new Map<string, Function>();
 
 let cachedRegisterServerReference: RegisterServerReferenceFn | null | undefined;
 
+export function configureServerReferenceRegistration(
+  registerServerReference: RegisterServerReferenceFn
+): void {
+  cachedRegisterServerReference = registerServerReference;
+}
+
 function getRegisterServerReference(): RegisterServerReferenceFn | null {
   if (cachedRegisterServerReference !== undefined) {
     return cachedRegisterServerReference;

--- a/scripts/test-server-runtime.cjs
+++ b/scripts/test-server-runtime.cjs
@@ -78,6 +78,10 @@ const actionRuntime = require(path.join(
   'server',
   'runtime-actions.ts'
 ));
+actionRuntime.configureServerReferenceRegistration((reference, id, exportName) => {
+  reference.$$typeof = Symbol.for('react.server.reference');
+  reference.$$id = `${id}#${exportName}`;
+});
 const { installModuleCompileHook } = require(path.join(
   repoRoot,
   'packages',
@@ -352,9 +356,32 @@ async function main() {
       'revalidatePath should remove static page artifacts'
     );
 
-    const tempProject = fs.mkdtempSync(path.join(repoRoot, '.tmp-inline-actions-'));
+    const tempProject = fs.mkdtempSync(
+      path.join(repoRoot, 'node_modules', '.tmp-inline-actions-')
+    );
     try {
-      installModuleCompileHook({ cwd: tempProject });
+      let clientProxyId;
+      installModuleCompileHook({
+        cwd: tempProject,
+        createClientModuleProxy: (id) => {
+          clientProxyId = id;
+          return { clientReference: true };
+        },
+      });
+
+      const clientModulePath = path.join(tempProject, 'client-boundary.js');
+      fs.writeFileSync(
+        clientModulePath,
+        ["'use client';", 'module.exports = { client: true };', ''].join('\n'),
+        'utf8'
+      );
+      delete require.cache[require.resolve(clientModulePath)];
+      assert.deepEqual(
+        require(clientModulePath),
+        { clientReference: true },
+        'Client boundaries under linked package node_modules paths should use a proxy'
+      );
+      assert.equal(clientProxyId, `file://${clientModulePath}`);
 
       const inlineModulePath = path.join(tempProject, 'inline-actions.js');
       fs.writeFileSync(
@@ -384,6 +411,17 @@ async function main() {
         registeredInlineAction,
         inlineAction,
         'Inline action should be registered through the compile hook'
+      );
+
+      assert.equal(
+        inlineAction.$$typeof,
+        Symbol.for('react.server.reference'),
+        'Inline action should be marked as a React server reference'
+      );
+      assert.equal(
+        inlineAction.$$id,
+        `${actionRuntime.createInlineServerActionId(inlineModulePath, 0, 'inlineEcho')}#inlineEcho`,
+        'Inline action should use its registered server reference id'
       );
 
       const exportedModulePath = path.join(tempProject, 'exported-actions.js');


### PR DESCRIPTION
Summary
Fixes RSC inline server actions not being registered when SWC emits FunctionBody nodes.
Ensures server action references use React’s RSC registration API.
Allows Vista’s own pnpm-linked runtime modules to pass through the compile hook.
Prevents client-only modules such as ThemeProvider from executing in the react-server runtime.
Adds regressions for inline actions and pnpm-linked client boundaries.

Testing
pnpm --filter @vistagenic/vista build
node scripts/test-server-runtime.cjs
node scripts/test-rsc-conformance.cjs
Verified apps/web returns 200 OK in development mode.
<img width="890" height="590" alt="Screenshot From 2026-09-05 22-54-04" src="https://github.com/user-attachments/assets/a7afcbba-ef8a-4ea9-851a-cd38f460152c" />
<img width="1910" height="996" alt="Screenshot From 2026-09-05 23-04-12" src="https://github.com/user-attachments/assets/610534ff-ea44-490c-a210-23adfb523b48" />
<img width="1046" height="603" alt="Screenshot From 2026-09-05 23-04-32" src="https://github.com/user-attachments/assets/8f8cbcff-f0c7-4c24-98d0-235e4300bdaf" />
